### PR TITLE
Add Developer + ITSM 5.0-documentation

### DIFF
--- a/doc/documentation.js
+++ b/doc/documentation.js
@@ -74,8 +74,14 @@ $(document).ready(function() {
             Path: 'itsm',
             Versions: [
                 {
+                    Version:  '5.0',
+                    HTMLPath: '5.0',
+                    Name:     'OTRS::ITSM 5',
+                    Languages: ['en', 'ru']
+                },
+                {
                     Version:  '4.0',
-                    HTMLPath: 'stable',
+                    HTMLPath: '4.0',
                     Name:     'OTRS::ITSM 4',
                     Languages: ['en', 'ru']
                 },
@@ -99,8 +105,14 @@ $(document).ready(function() {
             Path: 'developer',
             Versions: [
                 {
+                    Version:  '5.0',
+                    HTMLPath: '5.0',
+                    Name:     'OTRS 4',
+                    Languages: ['en']
+                },
+                {
                     Version:  '4.0',
-                    HTMLPath: 'stable',
+                    HTMLPath: '4.0',
                     Name:     'OTRS 4',
                     Languages: ['en']
                 },

--- a/doc/index.html
+++ b/doc/index.html
@@ -31,21 +31,21 @@
                 <span>Version 4</span>
             </a>
         </li>
-        <li data-target-id="manual_itsm_4_0">
-            <a href="manual/itsm/stable/en/html/index.html">
+        <li data-target-id="manual_itsm_5_0">
+            <a href="manual/itsm/5.0/en/html/index.html">
                 <span>Manual</span>
                 OTRS::ITSM
-                <span>Version 4</span>
+                <span>Version 5</span>
             </a>
         </li>
     </ul>
     <h2 class="Center">Developer Manuals</h2>
     <ul class="PagesList">
-        <li data-target-id="manual_developer_4_0">
-            <a href="manual/developer/stable/en/html/index.html">
+        <li data-target-id="manual_developer_5_0">
+            <a href="manual/developer/5.0/en/html/index.html">
                 <span>Manual</span>
                 OTRS Developer Manual
-                <span>Version 4</span>
+                <span>Version 5</span>
             </a>
         </li>
         <li data-target-id="api_otrs_5_0">


### PR DESCRIPTION
Developer and ITSM-Documentation for 5.0 is apparently already generated but not linked yet.

This should take care of it.

I did on purpose not link to the "stable"-folder, as those still contain 4.0-data...